### PR TITLE
Support reading config value from a string

### DIFF
--- a/src/main/java/com/apple/spark/AppConfig.java
+++ b/src/main/java/com/apple/spark/AppConfig.java
@@ -19,6 +19,7 @@
 
 package com.apple.spark;
 
+import com.apple.spark.core.ConfigValue;
 import com.apple.spark.operator.DriverSpec;
 import com.apple.spark.operator.ExecutorSpec;
 import com.apple.spark.operator.SparkUIConfiguration;
@@ -443,6 +444,14 @@ public class AppConfig extends Configuration {
     public void setEksCluster(String eksCluster) {
       this.eksCluster = eksCluster;
     }
+
+    public String getCaCertDataSOPSDecoded() {
+      return ConfigValue.tryGetEncodedSecretValue(caCertDataSOPS);
+    }
+
+    public String getUserTokenSOPSDecoded() {
+      return ConfigValue.tryGetEncodedSecretValue(userTokenSOPS);
+    }
   }
 
   @JsonIgnoreProperties(ignoreUnknown = true)
@@ -656,6 +665,10 @@ public class AppConfig extends Configuration {
 
     public void setDbName(String dbName) {
       this.dbName = dbName;
+    }
+
+    public String getPasswordDecodedValue() {
+      return ConfigValue.tryGetEncodedSecretValue(password);
     }
   }
 }

--- a/src/main/java/com/apple/spark/core/ApplicationMonitor.java
+++ b/src/main/java/com/apple/spark/core/ApplicationMonitor.java
@@ -95,7 +95,7 @@ public class ApplicationMonitor implements AutoCloseable {
     if (appConfig.getDbStorageSOPS() != null) {
       dbConnectionString = appConfig.getDbStorageSOPS().getConnectionString();
       dbUser = appConfig.getDbStorageSOPS().getUser();
-      dbPassword = appConfig.getDbStorageSOPS().getPassword();
+      dbPassword = appConfig.getDbStorageSOPS().getPasswordDecodedValue();
       dbName = appConfig.getDbStorageSOPS().getDbName();
     }
 

--- a/src/main/java/com/apple/spark/core/ConfigValue.java
+++ b/src/main/java/com/apple/spark/core/ConfigValue.java
@@ -1,0 +1,163 @@
+/*
+ *
+ * This source file is part of the Batch Processing Gateway open source project
+ *
+ * Copyright 2022 Apple Inc. and the Batch Processing Gateway project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.spark.core;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+
+public class ConfigValue {
+  private static final Logger logger = LoggerFactory.getLogger(ConfigValue.class);
+
+  private static final String PLAINTEXT_PREFIX = "plaintext:";
+
+  private static final String LOCALHOST_ENV_PREFIX = "localhost:env:";
+
+  private static final String K8S_SECRET_PREFIX = "k8s:secret:";
+
+  private ConfigValue() {}
+
+  /***
+   * This method tries to get secret value from an encoded string.
+   * Following are examples for encoded string:
+   * plaintext:value123 - get plaintext value like value123
+   * localhost:env:my_env_variable_name - get value from environment variable my_env_variable_name
+   * k8s:secret:namespace1:secret1:key1 - read secret secret1 in current kubernetes cluster and namespace namespace1, and get value for key1
+   *
+   * If the value is not in recognized encoding, this method will return the value directly.
+   * @param value
+   * @return
+   */
+  public static String tryGetEncodedSecretValue(String value) {
+    if (value == null || value.isEmpty()) {
+      return value;
+    }
+    if (value.startsWith(PLAINTEXT_PREFIX)) {
+      return value.substring(PLAINTEXT_PREFIX.length());
+    } else if (value.startsWith(LOCALHOST_ENV_PREFIX)) {
+      return tryGetEncodedSecretValueFromEnvVar(value);
+    } else if (value.startsWith(K8S_SECRET_PREFIX)) {
+      return tryGetEncodedSecretValueFromK8sSecret(value);
+    }
+    return value;
+  }
+
+  private static String tryGetEncodedSecretValueFromEnvVar(String value) {
+    logger.info(String.format("tryGetEncodedSecretValueFromEnvVar: %s", value));
+    String envVarName = value.substring(LOCALHOST_ENV_PREFIX.length());
+    String envValue = System.getenv(envVarName);
+    if (envValue == null) {
+      logger.info(String.format("Did not find env variable: %s", envVarName));
+      return value;
+    } else {
+      return envValue;
+    }
+  }
+
+  private static String tryGetEncodedSecretValueFromK8sSecret(String value) {
+    logger.info(String.format("tryGetEncodedSecretValueFromK8sSecret: %s", value));
+    String secretNameAndKey = value.substring(K8S_SECRET_PREFIX.length());
+    String[] strParts = secretNameAndKey.split(":");
+    if (strParts.length != 3) {
+      logger.info(String.format("Not valid encoded k8s secret value: %s", value));
+      return value;
+    }
+    String namespace = strParts[0];
+    if (namespace.isEmpty()) {
+      namespace = KubernetesHelper.tryGetServiceAccountNamespace();
+      if (namespace != null && !namespace.isEmpty()) {
+        logger.info(
+            String.format(
+                "Use current namespace %s for encoded k8s secret value: %s", namespace, value));
+      }
+    }
+    if (namespace == null || namespace.isEmpty()) {
+      logger.info(String.format("Cannot resolve namespace in encoded k8s secret value: %s", value));
+      return value;
+    }
+    String secretName = strParts[1];
+    String secretKey = strParts[2];
+    int retryTimes = 2;
+    int retryIntervalMillis = 1000;
+    for (int i = 0; i <= retryTimes; i++) {
+      try (DefaultKubernetesClient client = KubernetesHelper.getLocalK8sClient()) {
+        Secret secret = client.secrets().inNamespace(namespace).withName(secretName).get();
+        if (secret == null) {
+          logger.info(
+              String.format(
+                  "Secret %s not exists in namespace %s (encoded k8s secret value: %s)",
+                  secretName, namespace, value));
+          return value;
+        }
+        logger.info(
+            String.format(
+                "Found secret %s in namespace %s (encoded k8s secret value: %s)",
+                secretName, namespace, value));
+        Map<String, String> data = secret.getData();
+        if (data == null) {
+          logger.info(
+              String.format(
+                  "Secret %s has no data in namespace %s (encoded k8s secret value: %s)",
+                  secretName, namespace, value));
+          return value;
+        }
+        String secretValue = data.get(secretKey);
+        if (secretValue == null) {
+          logger.info(
+              String.format(
+                  "Secret %s has no data key %s in namespace %s (encoded k8s secret value: %s)",
+                  secretName, secretKey, namespace, value));
+          return value;
+        } else {
+          String base64DecodedStr =
+              new String(Base64.getDecoder().decode(secretValue), StandardCharsets.UTF_8);
+          logger.info(
+              String.format(
+                  "Secret %s got value (base64 encoded length: %d, base64 decoded length: %d) for"
+                      + " data key %s in namespace %s (encoded k8s secret value: %s)",
+                  secretName,
+                  secretValue.length(),
+                  base64DecodedStr.length(),
+                  secretKey,
+                  namespace,
+                  value));
+          return base64DecodedStr;
+        }
+      } catch (Throwable ex) {
+        logger.warn(
+            String.format(
+                "Failed to get secret %s in namespace %s (encoded k8s secret value: %s)",
+                secretName, namespace, value),
+            ex);
+        try {
+          Thread.sleep(retryIntervalMillis);
+        } catch (InterruptedException e) {
+          throw new RuntimeException(e);
+        }
+      }
+    }
+    return value;
+  }
+}

--- a/src/main/java/com/apple/spark/rest/ApplicationGetLogRest.java
+++ b/src/main/java/com/apple/spark/rest/ApplicationGetLogRest.java
@@ -100,7 +100,7 @@ public class ApplicationGetLogRest extends RestBase {
     if (appConfig.getDbStorageSOPS() != null) {
       dbConnectionString = appConfig.getDbStorageSOPS().getConnectionString();
       dbUser = appConfig.getDbStorageSOPS().getUser();
-      dbPassword = appConfig.getDbStorageSOPS().getPassword();
+      dbPassword = appConfig.getDbStorageSOPS().getPasswordDecodedValue();
       dbName = appConfig.getDbStorageSOPS().getDbName();
     }
 

--- a/src/main/java/com/apple/spark/rest/ApplicationSubmissionRest.java
+++ b/src/main/java/com/apple/spark/rest/ApplicationSubmissionRest.java
@@ -132,7 +132,7 @@ public class ApplicationSubmissionRest extends RestBase {
     if (appConfig.getDbStorageSOPS() != null) {
       dbConnectionString = appConfig.getDbStorageSOPS().getConnectionString();
       dbUser = appConfig.getDbStorageSOPS().getUser();
-      dbPassword = appConfig.getDbStorageSOPS().getPassword();
+      dbPassword = appConfig.getDbStorageSOPS().getPasswordDecodedValue();
       dbName = appConfig.getDbStorageSOPS().getDbName();
     }
 

--- a/src/main/java/com/apple/spark/util/ConfigUtil.java
+++ b/src/main/java/com/apple/spark/util/ConfigUtil.java
@@ -78,7 +78,7 @@ public class ConfigUtil {
     AppConfig.DBStorage dbconf = config.getDbStorageSOPS();
     String connectionString = dbconf.getConnectionString();
     String userId = dbconf.getUser();
-    String password = dbconf.getPassword();
+    String password = dbconf.getPasswordDecodedValue();
     String queryConf = "SELECT cid, conf FROM config";
 
     DBConnection dbConnection = new DBConnection(connectionString, userId, password);

--- a/src/test/java/com/apple/spark/core/ConfigValueTest.java
+++ b/src/test/java/com/apple/spark/core/ConfigValueTest.java
@@ -1,0 +1,55 @@
+/*
+ *
+ * This source file is part of the Batch Processing Gateway open source project
+ *
+ * Copyright 2022 Apple Inc. and the Batch Processing Gateway project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.spark.core;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class ConfigValueTest {
+
+  @Test
+  public void tryGetEncodedSecretValue() {
+    String value = ConfigValue.tryGetEncodedSecretValue(null);
+    Assert.assertNull(value);
+
+    value = ConfigValue.tryGetEncodedSecretValue("");
+    Assert.assertEquals(value, "");
+
+    value = ConfigValue.tryGetEncodedSecretValue("abc123");
+    Assert.assertEquals(value, "abc123");
+
+    value = ConfigValue.tryGetEncodedSecretValue("plaintext:abc123");
+    Assert.assertEquals(value, "abc123");
+
+    value =
+        ConfigValue.tryGetEncodedSecretValue(
+            "localhost:env:not_existing_env_variable_b50dd229-00a8-410e-a279-a22e6bad0a4c");
+    Assert.assertEquals(
+        value, "localhost:env:not_existing_env_variable_b50dd229-00a8-410e-a279-a22e6bad0a4c");
+
+    String envVariableNameForTest = System.getenv().keySet().stream().findFirst().get();
+    String envVariableValueForTest = System.getenv(envVariableNameForTest);
+    value = ConfigValue.tryGetEncodedSecretValue("localhost:env:" + envVariableNameForTest);
+    Assert.assertEquals(value, envVariableValueForTest);
+
+    value = ConfigValue.tryGetEncodedSecretValue("k8s:secret:invalid_value");
+    Assert.assertEquals(value, "k8s:secret:invalid_value");
+  }
+}


### PR DESCRIPTION
## What is the Purpose of the Change

Support reading config value from string like 
```
k8s:secret:namespace1:secret_name:secret_key
```
This enables storing credential values in k8s secret instead of in gateway config.

## Type of Change
<!-- Put an "X" in the [ ] as [ X ] to mark the selection -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Brief Change Log

Support reading config value from string like 
```
k8s:secret:namespace1:secret_name:secret_key
```
This enables storing credential values in k8s secret instead of in gateway config.


## Verifying This Change

Manually tested

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)


# Final Checklist:
<!-- Put an "X" in the [ ] as [ X ] to mark the selection -->

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
