### PR TITLE
Fixed wrong example of arguments field in Swagger API doc

### DIFF
--- a/src/main/java/com/apple/spark/api/SubmitApplicationRequest.java
+++ b/src/main/java/com/apple/spark/api/SubmitApplicationRequest.java
@@ -76,7 +76,6 @@ public class SubmitApplicationRequest {
               + " provide the full path to the Python file.")
   private String mainApplicationFile;
 
-  @Schema(description = "Any arguments that should be passed in", example = "['--date', date]")
   private List<String> arguments;
 
   private Map<String, String> sparkConf;


### PR DESCRIPTION
<!--
*Thank you for contributing.
To help others review your PR in the best possible way, please go through the checklist below,
which will get your PR into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make PR submission a hassle. 
In order to uphold a high standard of quality for code contributions, while at the same time keeping track
of the development work, we need PR authors to prepare the PRs well, and give reviewers enough contextual information for the review. *

## Contribution Checklist

  - Name the pull request in the form "[Component] A one-liner summary of the change".
    You may skip the [Component] if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests (TO BE ADDED).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message. Include issue links if possible.

  - Remove the above text and this checklist, leaving only the filled out template below.
-->

## What is the Purpose of the Change

When users refer to the Swagger UI to submit a job using the Skate API `/spark` endpoint, they see a wrong example:

![image](https://github.com/apple/batch-processing-gateway/assets/1168769/f9662936-9198-4504-87c4-eda338279cc7)

Arguments should be a list, not a string. It's a minor error but has caused multiple instances of user confusion. Removed the example. Swagger will automatically indicate it's a list of strings that should be provided


## Type of Change
<!-- Put an "X" in the [ ] as [ X ] to mark the selection -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Verifying This Change

This change is a trivial rework / code cleanup without any test coverage.
