### PR TITLE
[Core]: Apply zone constraints as node affinity to spark CRD

### DIFF
--- a/src/main/java/com/apple/spark/AppConfig.java
+++ b/src/main/java/com/apple/spark/AppConfig.java
@@ -522,6 +522,8 @@ public class AppConfig extends Configuration {
     private double driverMemBufferRatio = 1.0;
     private double executorMemBufferRatio = 1.0;
     private Integer maxExecutorInstances;
+    private List<String> allowedZones;
+    private String zonePickerName;
 
     public String getName() {
       return name;
@@ -637,6 +639,22 @@ public class AppConfig extends Configuration {
 
     public void setMaxExecutorInstances(Integer maxExecutorInstances) {
       this.maxExecutorInstances = maxExecutorInstances;
+    }
+
+    public List<String> getAllowedZones() {
+      return allowedZones;
+    }
+
+    public void setAllowedZones(final List<String> allowedZones) {
+      this.allowedZones = allowedZones;
+    }
+
+    public String getZonePickerName() {
+      return zonePickerName;
+    }
+
+    public void setZonePickerName(final String zonePickerName) {
+      this.zonePickerName = zonePickerName;
     }
   }
 

--- a/src/main/java/com/apple/spark/core/Constants.java
+++ b/src/main/java/com/apple/spark/core/Constants.java
@@ -65,6 +65,8 @@ public class Constants {
   public static final String EXCEPTION_METER = "Exception.exceptions";
   public static final String CONFIG_MAX_RUNNING_MILLIS =
       String.format("%s.maxRunningMillis", SERVICE_ABBR);
+  public static final String CONFIG_PICKED_ZONES = String.format("%s.pickedZones", SERVICE_ABBR);
+  public static final String PICKED_ZONES_DELIMITER = ",";
   public static final int APPLICATION_MONITOR_QUEUE_CAPACITY = 100000;
   public static final long DEFAULT_STATUS_CACHE_EXPIRE_MILLIS = 990;
   public static final String DRIVER_NODE_AFFINITY_KEY = "node_group_category";

--- a/src/main/java/com/apple/spark/core/RoundRobinZonePicker.java
+++ b/src/main/java/com/apple/spark/core/RoundRobinZonePicker.java
@@ -1,0 +1,34 @@
+package com.apple.spark.core;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class RoundRobinZonePicker implements ZonePicker {
+
+  private List<String> allowedZones;
+  private final AtomicInteger index = new AtomicInteger(0);
+
+  public RoundRobinZonePicker() {}
+
+  @Override
+  public void update(final List<String> allowedZones) {
+    if (allowedZones == null || allowedZones.isEmpty()) {
+      throw new RuntimeException("Invalid allowedZones: Empty");
+    }
+    if (allowedZones.stream().anyMatch(Objects::isNull)
+        || allowedZones.stream().anyMatch(String::isEmpty)) {
+      throw new RuntimeException("Invalid allowedZones: Some zone is empty");
+    }
+    this.allowedZones = allowedZones;
+    this.index.set(0);
+  }
+
+  @Override
+  public List<String> pick() {
+    int zoneIndex = index.getAndUpdate((input) -> (input + 1) % allowedZones.size());
+    String pickedZone = allowedZones.get(zoneIndex);
+    return Collections.singletonList(pickedZone);
+  }
+}

--- a/src/main/java/com/apple/spark/core/SparkPodNodeAffinityHelper.java
+++ b/src/main/java/com/apple/spark/core/SparkPodNodeAffinityHelper.java
@@ -52,8 +52,7 @@ public class SparkPodNodeAffinityHelper {
     return nodeAffinity;
   }
 
-  @VisibleForTesting
-  protected static NodeSelectorTerm createNodeSelectorTermForRequired(
+  private static NodeSelectorTerm createNodeSelectorTermForRequired(
       final SubmitApplicationRequest request,
       final AppConfig appConfig,
       final String queue,

--- a/src/main/java/com/apple/spark/core/SparkPodNodeAffinityHelper.java
+++ b/src/main/java/com/apple/spark/core/SparkPodNodeAffinityHelper.java
@@ -1,0 +1,221 @@
+/*
+ *
+ * This source file is part of the Batch Processing Gateway open source project
+ *
+ * Copyright 2022 Apple Inc. and the Batch Processing Gateway project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.spark.core;
+
+import static com.apple.spark.core.Constants.*;
+
+import com.apple.spark.AppConfig;
+import com.apple.spark.api.SubmitApplicationRequest;
+import com.apple.spark.operator.*;
+import com.google.common.annotations.VisibleForTesting;
+import java.util.*;
+
+public class SparkPodNodeAffinityHelper {
+
+  public static final String K8S_ZONE_LABEL = "topology.kubernetes.io/zone";
+
+  public static NodeAffinity createNodeAffinityForSparkPods(
+      final SubmitApplicationRequest request,
+      final AppConfig appConfig,
+      final String queueName,
+      final AppConfig.SparkCluster sparkCluster,
+      final boolean isDriver) {
+
+    NodeAffinity nodeAffinity = new NodeAffinity();
+
+    NodeSelectorTerm nodeSelectorTermForRequired =
+        createNodeSelectorTermForRequired(request, appConfig, queueName, sparkCluster, isDriver);
+
+    if (nodeSelectorTermForRequired.getMatchExpressions() != null) {
+      nodeAffinity.setRequiredDuringSchedulingIgnoredDuringExecution(
+          new RequiredDuringSchedulingIgnoredDuringExecutionTerm(
+              new NodeSelectorTerm[] {nodeSelectorTermForRequired}));
+    }
+
+    return nodeAffinity;
+  }
+
+  @VisibleForTesting
+  protected static NodeSelectorTerm createNodeSelectorTermForRequired(
+      final SubmitApplicationRequest request,
+      final AppConfig appConfig,
+      final String queue,
+      final AppConfig.SparkCluster sparkCluster,
+      final boolean isDriver) {
+
+    NodeSelectorTerm podNodeSelectorTerm = new NodeSelectorTerm();
+    List<NodeSelectorRequirement> matchExpressions = new ArrayList<>();
+
+    if (isDriver) {
+      applyDriverNodeLabelAffinity(matchExpressions, appConfig, queue);
+    } else {
+      applyExecutorNodeLabelAffinity(matchExpressions, request, appConfig, queue);
+    }
+    applyAvailabilityZoneExpression(matchExpressions, request);
+
+    if (!matchExpressions.isEmpty()) {
+      podNodeSelectorTerm.setMatchExpressions(
+          matchExpressions.toArray(NodeSelectorRequirement[]::new));
+    }
+    return podNodeSelectorTerm;
+  }
+
+  @VisibleForTesting
+  protected static void applyAvailabilityZoneExpression(
+      final List<NodeSelectorRequirement> matchExpressions,
+      final SubmitApplicationRequest request) {
+
+    if (request == null
+        || request.getSparkConf() == null
+        || !request.getSparkConf().containsKey(CONFIG_PICKED_ZONES)
+        || request.getSparkConf().get(CONFIG_PICKED_ZONES) == null
+        || request.getSparkConf().get(CONFIG_PICKED_ZONES).isEmpty()) {
+      return;
+    }
+
+    String[] pickedZone =
+        request.getSparkConf().get(CONFIG_PICKED_ZONES).split(PICKED_ZONES_DELIMITER);
+    if (pickedZone.length == 0) {
+      return;
+    }
+
+    matchExpressions.add(
+        new NodeSelectorRequirement(
+            K8S_ZONE_LABEL, NodeSelectorOperator.NodeSelectorOpIn.toString(), pickedZone));
+  }
+
+  private static void applyDriverNodeLabelAffinity(
+      final List<NodeSelectorRequirement> matchExpressions,
+      final AppConfig appConfig,
+      final String parentQueue) {
+    List<String> driverNodeLabelValues = getDriverNodeLabelValuesForQueue(appConfig, parentQueue);
+    String nodeLabelKey = getDriverNodeLabelKeyForQueue(appConfig, parentQueue);
+    if (driverNodeLabelValues == null || driverNodeLabelValues.isEmpty()) {
+      return;
+    }
+    // set hard requiredDuringSchedulingIgnoredDuringExecutionTerm to driver
+    NodeSelectorRequirement nodeSelectorRequirement =
+        new NodeSelectorRequirement(
+            nodeLabelKey,
+            NodeSelectorOperator.NodeSelectorOpIn.toString(),
+            driverNodeLabelValues.toArray(new String[0])); // set "spark_driver" as nodeselctor
+
+    matchExpressions.add(nodeSelectorRequirement);
+  }
+
+  private static String getDriverNodeLabelKeyForQueue(AppConfig appConfig, String queue) {
+    Optional<AppConfig.QueueConfig> queueConfigOptional =
+        appConfig.getQueues().stream().filter(t -> t.getName().equals(queue)).findFirst();
+
+    if (queueConfigOptional.isPresent()) {
+      AppConfig.QueueConfig queueConfig = queueConfigOptional.get();
+      if (queueConfig != null && queueConfig.getDriverNodeLabelKey() != null) {
+        return queueConfig.getDriverNodeLabelKey();
+      }
+    }
+    return DEFAULT_DRIVER_NODE_LABEL_KEY;
+  }
+
+  private static List<String> getDriverNodeLabelValuesForQueue(AppConfig appConfig, String queue) {
+    Optional<AppConfig.QueueConfig> queueConfigOptional =
+        appConfig.getQueues().stream().filter(t -> t.getName().equals(queue)).findFirst();
+    List<String> res = new ArrayList<>();
+
+    if (queueConfigOptional.isPresent()) {
+      AppConfig.QueueConfig queueConfig = queueConfigOptional.get();
+      if (queueConfig != null && queueConfig.getDriverNodeLabelValues() != null) {
+        res.addAll(queueConfig.getDriverNodeLabelValues());
+      }
+    }
+    return res;
+  }
+
+  private static void applyExecutorNodeLabelAffinity(
+      final List<NodeSelectorRequirement> matchExpressions,
+      final SubmitApplicationRequest request,
+      final AppConfig appConfig,
+      final String parentQueue) {
+
+    List<String> executorNodeLabelValues = new ArrayList<>();
+
+    if (request.getSpotInstance()) {
+      executorNodeLabelValues = getExecutorSpotNodeLabelValuesForQueue(appConfig, parentQueue);
+    } else {
+      executorNodeLabelValues = getExecutorNodeLabelValuesForQueue(appConfig, parentQueue);
+    }
+
+    String nodeLabelKey = getExecutorNodeLabelKeyForQueue(appConfig, parentQueue);
+
+    if (executorNodeLabelValues == null || executorNodeLabelValues.isEmpty()) {
+      return;
+    }
+    // set hard requiredDuringSchedulingIgnoredDuringExecutionTerm to executor
+    NodeSelectorRequirement nodeSelectorRequirement =
+        new NodeSelectorRequirement(
+            nodeLabelKey,
+            NodeSelectorOperator.NodeSelectorOpIn.toString(),
+            executorNodeLabelValues.toArray(new String[0]));
+
+    matchExpressions.add(nodeSelectorRequirement);
+  }
+
+  private static List<String> getExecutorSpotNodeLabelValuesForQueue(
+      AppConfig appConfig, String queue) {
+    Optional<AppConfig.QueueConfig> queueConfigOptional =
+        appConfig.getQueues().stream().filter(t -> t.getName().equals(queue)).findFirst();
+    List<String> res = new ArrayList<>();
+
+    if (queueConfigOptional.isPresent()) {
+      AppConfig.QueueConfig queueConfig = queueConfigOptional.get();
+      if (queueConfig != null && queueConfig.getExecutorSpotNodeLabelValues() != null) {
+        res.addAll(queueConfig.getExecutorSpotNodeLabelValues());
+      }
+    }
+    return res;
+  }
+
+  private static String getExecutorNodeLabelKeyForQueue(AppConfig appConfig, String queue) {
+    Optional<AppConfig.QueueConfig> queueConfigOptional =
+        appConfig.getQueues().stream().filter(t -> t.getName().equals(queue)).findFirst();
+
+    if (queueConfigOptional.isPresent()) {
+      AppConfig.QueueConfig queueConfig = queueConfigOptional.get();
+      if (queueConfig != null && queueConfig.getExecutorNodeLabelKey() != null) {
+        return queueConfig.getExecutorNodeLabelKey();
+      }
+    }
+    return DEFAULT_EXECUTOR_NODE_LABEL_KEY;
+  }
+
+  private static List<String> getExecutorNodeLabelValuesForQueue(
+      AppConfig appConfig, String queue) {
+    Optional<AppConfig.QueueConfig> queueConfigOptional =
+        appConfig.getQueues().stream().filter(t -> t.getName().equals(queue)).findFirst();
+    List<String> res = new ArrayList<>();
+
+    if (queueConfigOptional.isPresent()) {
+      AppConfig.QueueConfig queueConfig = queueConfigOptional.get();
+      if (queueConfig != null && queueConfig.getExecutorNodeLabelValues() != null) {
+        res.addAll(queueConfig.getExecutorNodeLabelValues());
+      }
+    }
+    return res;
+  }
+}

--- a/src/main/java/com/apple/spark/core/ZoneManager.java
+++ b/src/main/java/com/apple/spark/core/ZoneManager.java
@@ -1,0 +1,81 @@
+package com.apple.spark.core;
+
+import com.apple.spark.AppConfig;
+import com.apple.spark.AppConfig.QueueConfig;
+import com.apple.spark.api.SubmitApplicationRequest;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ZoneManager {
+  private static final Logger logger = LoggerFactory.getLogger(ZoneManager.class);
+  public static final String ROUND_ROBIN_ZONE_PICKER_NAME = "round_robin";
+  private static final ConcurrentMap<String, ZonePicker> zonePickers = new ConcurrentHashMap<>();
+
+  public static List<String> pickZones(
+      final SubmitApplicationRequest request,
+      final AppConfig appConfig,
+      final String queueName,
+      final AppConfig.SparkCluster sparkCluster,
+      final String submissionId) {
+
+    if (request == null || appConfig == null) {
+      return null;
+    }
+
+    Optional<QueueConfig> queueConfigOptional =
+        appConfig.getQueues().stream().filter(t -> t.getName().equals(queueName)).findFirst();
+
+    if (queueConfigOptional.isEmpty()) {
+      return null;
+    }
+
+    QueueConfig queueConfig = queueConfigOptional.get();
+
+    List<String> allowedZone = queueConfig.getAllowedZones();
+
+    if (allowedZone == null || allowedZone.isEmpty()) {
+      return null;
+    }
+
+    List<String> pickedZones =
+        zonePickers
+            .computeIfAbsent(queueConfig.getName(), (name) -> createZonePickerForQueue(queueConfig))
+            .pick();
+
+    logger.info(
+        "Picked Zones: {} for job: {} in Queue: {}",
+        String.join(",", pickedZones),
+        submissionId,
+        queueConfig.getName());
+
+    return pickedZones;
+  }
+
+  private static ZonePicker createZonePickerForQueue(final QueueConfig queueConfig) {
+    String zonePickerName = queueConfig.getZonePickerName();
+    if (zonePickerName == null) {
+      zonePickerName = ROUND_ROBIN_ZONE_PICKER_NAME;
+    }
+
+    ZonePicker zonePicker;
+    switch (zonePickerName) {
+      case ROUND_ROBIN_ZONE_PICKER_NAME:
+        zonePicker = new RoundRobinZonePicker();
+        break;
+      default:
+        zonePicker = new RoundRobinZonePicker();
+    }
+
+    zonePicker.update(queueConfig.getAllowedZones());
+    logger.info(
+        "Creating {} ZonePicker for Queue {} with AllowedAvailabilityZones {}",
+        zonePickerName,
+        queueConfig.getName(),
+        String.join(",", queueConfig.getAllowedZones()));
+    return zonePicker;
+  }
+}

--- a/src/main/java/com/apple/spark/core/ZonePicker.java
+++ b/src/main/java/com/apple/spark/core/ZonePicker.java
@@ -1,0 +1,10 @@
+package com.apple.spark.core;
+
+import java.util.List;
+
+public interface ZonePicker {
+  void update(List<String> allowedAvailabilityZones);
+
+  // return a list of zone ids, order matters
+  List<String> pick();
+}

--- a/src/main/java/com/apple/spark/rest/ApplicationSubmissionRest.java
+++ b/src/main/java/com/apple/spark/rest/ApplicationSubmissionRest.java
@@ -59,7 +59,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -1026,8 +1025,7 @@ public class ApplicationSubmissionRest extends RestBase {
     }
   }
 
-  @VisibleForTesting
-  protected void configureZonesForRequest(
+  private void configureZonesForRequest(
       final SubmitApplicationRequest request,
       final AppConfig appConfig,
       final String queueName,

--- a/src/test/java/com/apple/spark/core/SparkPodNodeAffinityHelperTest.java
+++ b/src/test/java/com/apple/spark/core/SparkPodNodeAffinityHelperTest.java
@@ -1,0 +1,113 @@
+/*
+ *
+ * This source file is part of the Batch Processing Gateway open source project
+ *
+ * Copyright 2022 Apple Inc. and the Batch Processing Gateway project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.spark.core;
+
+import static com.apple.spark.core.Constants.CONFIG_PICKED_ZONES;
+import static com.apple.spark.core.SparkPodNodeAffinityHelper.*;
+
+import com.apple.spark.AppConfig;
+import com.apple.spark.api.SubmitApplicationRequest;
+import com.apple.spark.operator.*;
+import java.util.*;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class SparkPodNodeAffinityHelperTest {
+
+  @Test
+  public void apply_null_allowed_zone() {
+    SubmitApplicationRequest request = new SubmitApplicationRequest();
+    request.setSparkConf(new HashMap<>());
+    List<NodeSelectorRequirement> matchExpressions = new ArrayList<>();
+    applyAvailabilityZoneExpression(matchExpressions, request);
+    Assert.assertEquals(matchExpressions.size(), 0);
+  }
+
+  @Test
+  public void apply_zero_allowed_zone() {
+    SubmitApplicationRequest request = new SubmitApplicationRequest();
+    request.setSparkConf(Map.of(CONFIG_PICKED_ZONES, ""));
+    List<NodeSelectorRequirement> matchExpressions = new ArrayList<>();
+    applyAvailabilityZoneExpression(matchExpressions, request);
+    Assert.assertEquals(matchExpressions.size(), 0);
+  }
+
+  @Test
+  public void apply_one_allowed_zone() {
+    SubmitApplicationRequest request = new SubmitApplicationRequest();
+    request.setSparkConf(Map.of(CONFIG_PICKED_ZONES, "ZoneA"));
+    List<NodeSelectorRequirement> matchExpressions = new ArrayList<>();
+    applyAvailabilityZoneExpression(matchExpressions, request);
+    Assert.assertEquals(matchExpressions.size(), 1);
+    Assert.assertEquals(matchExpressions.get(0).getKey(), K8S_ZONE_LABEL);
+    Assert.assertEquals(matchExpressions.get(0).getValues()[0], "ZoneA");
+  }
+
+  @Test
+  public void apply_two_allowed_zones() {
+    SubmitApplicationRequest request = new SubmitApplicationRequest();
+    request.setSparkConf(Map.of(CONFIG_PICKED_ZONES, "ZoneA,ZoneB"));
+    List<NodeSelectorRequirement> matchExpressions = new ArrayList<>();
+    applyAvailabilityZoneExpression(matchExpressions, request);
+
+    Assert.assertEquals(matchExpressions.size(), 1);
+    Assert.assertEquals(matchExpressions.get(0).getKey(), K8S_ZONE_LABEL);
+    Assert.assertEquals(matchExpressions.get(0).getValues()[0], "ZoneA");
+    Assert.assertEquals(matchExpressions.get(0).getValues()[1], "ZoneB");
+  }
+
+  @Test
+  public void consistent_zones_pick_driver_executor() {
+    SubmitApplicationRequest request = new SubmitApplicationRequest();
+    request.setSparkConf(Map.of(CONFIG_PICKED_ZONES, "ZoneA"));
+    AppConfig appConfig = new AppConfig();
+    AppConfig.QueueConfig queueConfig = new AppConfig.QueueConfig();
+    queueConfig.setName("test-queue");
+    appConfig.setQueues(List.of(queueConfig));
+    ExecutorSpec executorSpec = new ExecutorSpec();
+    request.setExecutor(executorSpec);
+
+    NodeAffinity driverNodeAffinity =
+        createNodeAffinityForSparkPods(request, appConfig, "test-queue", null, true);
+
+    NodeSelectorRequirement[] driverMatchExpressions =
+        driverNodeAffinity
+            .getRequiredDuringSchedulingIgnoredDuringExecution()
+            .getNodeSelectorTerms()[0]
+            .getMatchExpressions();
+    Assert.assertEquals(driverMatchExpressions.length, 1);
+    Assert.assertEquals(driverMatchExpressions[0].getKey(), K8S_ZONE_LABEL);
+    Assert.assertEquals(driverMatchExpressions[0].getValues().length, 1);
+    Assert.assertEquals(driverMatchExpressions[0].getValues()[0], "ZoneA");
+
+    NodeAffinity executorNodeAffinity =
+        createNodeAffinityForSparkPods(request, appConfig, "test-queue", null, false);
+
+    NodeSelectorRequirement[] executorMatchExpressions =
+        executorNodeAffinity
+            .getRequiredDuringSchedulingIgnoredDuringExecution()
+            .getNodeSelectorTerms()[0]
+            .getMatchExpressions();
+    Assert.assertEquals(executorMatchExpressions.length, 1);
+    Assert.assertEquals(executorMatchExpressions[0].getKey(), K8S_ZONE_LABEL);
+    Assert.assertEquals(executorMatchExpressions[0].getValues().length, 1);
+    Assert.assertEquals(executorMatchExpressions[0].getValues()[0], "ZoneA");
+  }
+}

--- a/src/test/java/com/apple/spark/core/ZoneManagerTest.java
+++ b/src/test/java/com/apple/spark/core/ZoneManagerTest.java
@@ -1,0 +1,188 @@
+package com.apple.spark.core;
+
+import static com.apple.spark.core.ZoneManager.ROUND_ROBIN_ZONE_PICKER_NAME;
+
+import com.apple.spark.AppConfig;
+import com.apple.spark.api.SubmitApplicationRequest;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class ZoneManagerTest {
+
+  @Test
+  private void testNoZoneSetInQueue() {
+    SubmitApplicationRequest request = new SubmitApplicationRequest();
+    AppConfig appConfig = new AppConfig();
+    String queueName = "test-queue-no-zone-set";
+    String submissionId = "test-submission-id";
+    AppConfig.QueueConfig testQueueConfig = new AppConfig.QueueConfig();
+    testQueueConfig.setName(queueName);
+    appConfig.setQueues(List.of(testQueueConfig));
+    AppConfig.SparkCluster sparkClusterSpec = new AppConfig.SparkCluster();
+
+    List<String> output =
+        ZoneManager.pickZones(request, appConfig, queueName, sparkClusterSpec, submissionId);
+
+    Assert.assertNull(output);
+  }
+
+  @Test
+  private void testEmptyZoneListSetInQueue() {
+    SubmitApplicationRequest request = new SubmitApplicationRequest();
+    AppConfig appConfig = new AppConfig();
+    String queueName = "test-queue-empty-zone-list";
+    String submissionId = "test-submission-id";
+    AppConfig.QueueConfig testQueueConfig = new AppConfig.QueueConfig();
+    testQueueConfig.setAllowedZones(Collections.emptyList());
+    testQueueConfig.setName(queueName);
+    appConfig.setQueues(List.of(testQueueConfig));
+    AppConfig.SparkCluster sparkClusterSpec = new AppConfig.SparkCluster();
+
+    List<String> output =
+        ZoneManager.pickZones(request, appConfig, queueName, sparkClusterSpec, submissionId);
+
+    Assert.assertNull(output);
+  }
+
+  @Test
+  private void testSomeEmptyZoneSetInQueue() {
+    SubmitApplicationRequest request = new SubmitApplicationRequest();
+    AppConfig appConfig = new AppConfig();
+    String queueName = "test-queue-some-empty-zone";
+    String submissionId = "test-submission-id";
+    AppConfig.QueueConfig testQueueConfig = new AppConfig.QueueConfig();
+    List<String> list = new ArrayList<>();
+    list.add(null);
+    testQueueConfig.setAllowedZones(list);
+    testQueueConfig.setName(queueName);
+    appConfig.setQueues(List.of(testQueueConfig));
+    AppConfig.SparkCluster sparkClusterSpec = new AppConfig.SparkCluster();
+
+    Assert.assertThrows(
+        RuntimeException.class,
+        () -> ZoneManager.pickZones(request, appConfig, queueName, sparkClusterSpec, submissionId));
+  }
+
+  @Test
+  private void testOneZone() {
+    SubmitApplicationRequest request = new SubmitApplicationRequest();
+    AppConfig appConfig = new AppConfig();
+    String queueName = "test-queue-one-zone-one-queue";
+    String submissionId = "test-submission-id";
+    AppConfig.QueueConfig testQueueConfig = new AppConfig.QueueConfig();
+    testQueueConfig.setName(queueName);
+    testQueueConfig.setAllowedZones(List.of("ZoneA"));
+    appConfig.setQueues(List.of(testQueueConfig));
+    AppConfig.SparkCluster sparkClusterSpec = new AppConfig.SparkCluster();
+
+    List<String> output =
+        ZoneManager.pickZones(request, appConfig, queueName, sparkClusterSpec, submissionId);
+
+    Assert.assertEquals(output.size(), 1);
+    Assert.assertEquals(output.get(0), "ZoneA");
+  }
+
+  @Test
+  private void testRoundRobinTwoZones() {
+    SubmitApplicationRequest request1 = new SubmitApplicationRequest();
+    String submissionId1 = "test-submission-id-1";
+    AppConfig appConfig = new AppConfig();
+    String queueName = "test-queue-two-zone-one-queue";
+    AppConfig.QueueConfig testQueueConfig = new AppConfig.QueueConfig();
+    testQueueConfig.setName(queueName);
+    testQueueConfig.setAllowedZones(List.of("ZoneA", "ZoneB"));
+    testQueueConfig.setZonePickerName(ROUND_ROBIN_ZONE_PICKER_NAME);
+    appConfig.setQueues(List.of(testQueueConfig));
+    AppConfig.SparkCluster sparkClusterSpec = new AppConfig.SparkCluster();
+
+    List<String> pick1 =
+        ZoneManager.pickZones(request1, appConfig, queueName, sparkClusterSpec, submissionId1);
+
+    Assert.assertEquals(pick1.size(), 1);
+    Assert.assertEquals(pick1.get(0), "ZoneA");
+
+    SubmitApplicationRequest request2 = new SubmitApplicationRequest();
+    String submissionId2 = "test-submission-id-2";
+
+    List<String> pick2 =
+        ZoneManager.pickZones(request2, appConfig, queueName, sparkClusterSpec, submissionId2);
+
+    Assert.assertEquals(pick2.size(), 1);
+    Assert.assertEquals(pick2.get(0), "ZoneB");
+
+    SubmitApplicationRequest request3 = new SubmitApplicationRequest();
+    String submissionId3 = "test-submission-id-3";
+
+    List<String> pick3 =
+        ZoneManager.pickZones(request3, appConfig, queueName, sparkClusterSpec, submissionId3);
+
+    Assert.assertEquals(pick3.size(), 1);
+    Assert.assertEquals(pick3.get(0), "ZoneA");
+  }
+
+  @Test
+  private void testRoundRobinTwoQueuesTwoZones() {
+    AppConfig appConfig = new AppConfig();
+    String queueName1 = "test-queue-two-zone-one-queue-1";
+    AppConfig.QueueConfig testQueueConfig1 = new AppConfig.QueueConfig();
+    testQueueConfig1.setName(queueName1);
+    testQueueConfig1.setAllowedZones(List.of("ZoneA", "ZoneB"));
+    testQueueConfig1.setZonePickerName(ROUND_ROBIN_ZONE_PICKER_NAME);
+
+    String queueName2 = "test-queue-two-zone-one-queue-2";
+    AppConfig.QueueConfig testQueueConfig2 = new AppConfig.QueueConfig();
+    testQueueConfig2.setName(queueName2);
+    testQueueConfig2.setAllowedZones(List.of("ZoneC", "ZoneD"));
+    testQueueConfig2.setZonePickerName(ROUND_ROBIN_ZONE_PICKER_NAME);
+
+    appConfig.setQueues(List.of(testQueueConfig1, testQueueConfig2));
+    AppConfig.SparkCluster sparkClusterSpec = new AppConfig.SparkCluster();
+
+    List<String> q1pick1 =
+        ZoneManager.pickZones(
+            new SubmitApplicationRequest(),
+            appConfig,
+            queueName1,
+            sparkClusterSpec,
+            "test-submission-id-1");
+
+    Assert.assertEquals(q1pick1.size(), 1);
+    Assert.assertEquals(q1pick1.get(0), "ZoneA");
+
+    List<String> q2pick1 =
+        ZoneManager.pickZones(
+            new SubmitApplicationRequest(),
+            appConfig,
+            queueName2,
+            sparkClusterSpec,
+            "test-submission-id-2");
+
+    Assert.assertEquals(q2pick1.size(), 1);
+    Assert.assertEquals(q2pick1.get(0), "ZoneC");
+
+    List<String> q2pick2 =
+        ZoneManager.pickZones(
+            new SubmitApplicationRequest(),
+            appConfig,
+            queueName2,
+            sparkClusterSpec,
+            "test-submission-id-3");
+
+    Assert.assertEquals(q2pick2.size(), 1);
+    Assert.assertEquals(q2pick2.get(0), "ZoneD");
+
+    List<String> q1pick2 =
+        ZoneManager.pickZones(
+            new SubmitApplicationRequest(),
+            appConfig,
+            queueName1,
+            sparkClusterSpec,
+            "test-submission-id-4");
+
+    Assert.assertEquals(q1pick2.size(), 1);
+    Assert.assertEquals(q1pick2.get(0), "ZoneB");
+  }
+}


### PR DESCRIPTION
<!--
*Thank you for contributing.
To help others review your PR in the best possible way, please go through the checklist below,
which will get your PR into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make PR submission a hassle. 
In order to uphold a high standard of quality for code contributions, while at the same time keeping track
of the development work, we need PR authors to prepare the PRs well, and give reviewers enough contextual information for the review. *

## Contribution Checklist

  - Name the pull request in the form "[Component] A one-liner summary of the change".
    You may skip the [Component] if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests (TO BE ADDED).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message. Include issue links if possible.

  - Remove the above text and this checklist, leaving only the filled out template below.
-->

## What is the Purpose of the Change

Add node affinity to enforce all pods of the same job run in the same zone. Admin should supply a list of allowed zones for each queue. If no allowed zones are supplied, then there will be no node affinity applied.

## Type of Change
<!-- Put an "X" in the [ ] as [ X ] to mark the selection -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Brief Change Log

- Add node affinity to enforce all pods of the same job run in the same zone. 
- Add interface at QueueConfig to allow admin to choose zone picker and allowed zones
- Implement round robin zone picker and set as default
- Set picked zone into read-only Spark conf `spark.skate.pickedZones` 

## Verifying This Change
- Added unit tests
- Manually verified the change by running against a Spark cluster with 3 node groups across 3 zones.

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not documented


# Final Checklist:
<!-- Put an "X" in the [ ] as [ X ] to mark the selection -->

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
