### PR TITLE
Fix bitnami uri in setup-postgresql.sh

### DIFF
--- a/dev-setup/setup-postgresql.sh
+++ b/dev-setup/setup-postgresql.sh
@@ -14,5 +14,5 @@ grep -q local-postgresql <<<${installed} || \
     --set auth.database=${database} \
     --set auth.username=${username} \
     --set auth.password=${password} \
-    --repo https://charts.bitnami.com/bitnami \
-    local-postgresql postgresql
+    local-postgresql oci://registry-1.docker.io/bitnamicharts/postgresql
+


### PR DESCRIPTION
## What is the Purpose of the Change

While following the [GETTING_STARTED](https://github.com/apple/batch-processing-gateway/blob/main/docs/GETTING_STARTED.md) guide, the `setup-postgresql.sh` script throws the following error:

```
$ helm install -n local-postgresql --create-namespace \
    --set primary.service.type=NodePort \
    --set auth.database=${database} \
    --set auth.username=${username} \
    --set auth.password=${password} \
    --repo https://charts.bitnami.com/bitnami \
    local-postgresql postgresql
Error: INSTALLATION FAILED: invalid_reference: invalid tag
```

This PR fixes the Bitnami chart URI to resolve the issue.

## Type of Change
<!-- Put an "X" in the [ ] as [ X ] to mark the selection -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Verifying This Change

- Manually verified the change by running the script locally.



