### PR TITLE
Replace /apiv2 with /skatev2

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Refer to [KEY COMPONENTS](docs/KEY_COMPONENTS.md) for more details of the key co
 
 ![REST Endpoints](docs/images/rest_endpoints.png "REST Endpoints")
 
-BPG exposes REST endpoints to end users / clients for Spark apps, e.g. `POST /apiv2/spark` to submit a Spark app.
+BPG exposes REST endpoints to end users / clients for Spark apps, e.g. `POST /skatev2/spark` to submit a Spark app.
 The REST components receive the user requests, manipulate the requests when necessary, and interact with Spark clusters via [fabric8](https://github.com/fabric8io/kubernetes-client) Kubernetes client.
 
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -112,7 +112,7 @@ As an example, you can publish a minimal PySpark app under `/src/test/resources`
 
     $ export AWS_ACCESS_KEY_ID="${USER}"
     $ export AWS_SECRET_ACCESS_KEY=$(openssl rand -hex 32)
-    $ curl -u user_name:dummy_password http://localhost:8080/apiv2/s3/MinimalSparkApp.py\?folder=foo/ -X POST \
+    $ curl -u user_name:dummy_password http://localhost:8080/skatev2/s3/MinimalSparkApp.py\?folder=foo/ -X POST \
         --data-binary "@src/test/resources/MinimalSparkApp.py"
 
     {"url":"s3a://bpg/uploaded/foo/MinimalSparkApp.py"}
@@ -120,7 +120,7 @@ As an example, you can publish a minimal PySpark app under `/src/test/resources`
 ### Submit a Spark app
 Now the REST endpoints are running locally at `http://localhost:8080`. You can submit a Spark app to the Spark endpoint. If everything goes well, you should get a 200 response with a `submissionId`, which is a unique identifier of a submitted Spark app.
 
-    $ curl -u user_name:dummy_password http://localhost:8080/apiv2/spark -i -X POST \
+    $ curl -u user_name:dummy_password http://localhost:8080/skatev2/spark -i -X POST \
         -H 'Content-Type: application/json' \
         -d '{
             "sparkVersion": "3.2",
@@ -158,7 +158,7 @@ From here, the rest of the work is done by Spark Operator. It will enqueue the j
 Use the status API to query the job status:
 
     $ curl -u user_name:dummy_password \
-      http://localhost:8080/apiv2/spark/minikube-9a2e2598d1ee4ff4b33ee7ebcdb63a6c/status
+      http://localhost:8080/skatev2/spark/minikube-9a2e2598d1ee4ff4b33ee7ebcdb63a6c/status
     
     {"creationTime":1662961198000,"duration":0,"applicationState":"UNKNOWN"}
 
@@ -167,11 +167,11 @@ Use the status API to query the job status:
 Retrieve a full job description including the metadata in submission request:
 
     $ curl -u user_name:dummy_password \
-        http://localhost:8080/apiv2/spark/minikube-9a2e2598d1ee4ff4b33ee7ebcdb63a6c/describe
+        http://localhost:8080/skatev2/spark/minikube-9a2e2598d1ee4ff4b33ee7ebcdb63a6c/describe
 
 #### Get job driver log
     $ curl -u user_name:dummy_password \
-        http://localhost:8080/apiv2/log?subId=minikube-9a2e2598d1ee4ff4b33ee7ebcdb63a6c
+        http://localhost:8080/skatev2/log?subId=minikube-9a2e2598d1ee4ff4b33ee7ebcdb63a6c
 
 The health check endpoint runs on port 8081 by default. Check the server health by sending GET to `/healthcheck`, or simply open this in browser: http://localhost:8081/healthcheck
 ```bash

--- a/helm/batch-processing-gateway/README.md
+++ b/helm/batch-processing-gateway/README.md
@@ -36,7 +36,7 @@ Just a plain service available on port 80.
 
 ### Ingress
 
-- A version needs to be specified by user (currently `/apiv2`) so that we can support multiple versions if needed.
+- A version needs to be specified by user (currently `/skatev2`) so that we can support multiple versions if needed.
 - The upload request body is limited to 800m. You may adjust accordingly, but it can take much longer for large request bodies.
 
 ### Swagger UI

--- a/helm/batch-processing-gateway/templates/ingress.yaml
+++ b/helm/batch-processing-gateway/templates/ingress.yaml
@@ -18,7 +18,7 @@ spec:
                 name: bpg
                 port:
                   number: 80
-            path: /apiv2/(.*)
+            path: /skatev2/(.*)
             pathType: ImplementationSpecific
   tls:
     - hosts:


### PR DESCRIPTION
## What is the Purpose of the Change

The code use `/skatev2` as default url prefix. Need to change documentation to reflect that.


## Type of Change
<!-- Put an "X" in the [ ] as [ X ] to mark the selection -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ x] This change requires a documentation update


## Brief Change Log

Replace /apiv2 with /skatev2 in documentation.


## Verifying This Change

Run unit test.

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? docs


# Final Checklist:
<!-- Put an "X" in the [ ] as [ X ] to mark the selection -->

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
